### PR TITLE
attempt to parse JSON when GM_xmlhttpRequest is not supported

### DIFF
--- a/bin/enhanced-gog.user.js
+++ b/bin/enhanced-gog.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name enhanced-gog
 // @namespace https://github.com/kevinfiol/enhanced-gog
-// @version 1.4.4
+// @version 1.4.5
 // @description Enhanced experience on GOG.com
 // @license MIT; https://raw.githubusercontent.com/kevinfiol/enhanced-gog/master/LICENSE
 // @include http://*.gog.com/game/*
@@ -119,7 +119,7 @@
   m.retain = (_) => m(RETAIN_KEY);
 
   // src/config.js
-  var VERSION = "1.4.4";
+  var VERSION = "1.4.5";
   var API_KEY = "d047b30e0fc7d9118f3953de04fa6af9eba22379";
 
   // src/state.js
@@ -217,7 +217,13 @@
         xhr.open(method, `${url}?${queryStr}`);
         xhr.onload = () => {
           if (xhr.status >= 200 && xhr.status < 300) {
-            resolve(xhr.response);
+            let text = xhr.response;
+            try {
+              text = JSON.parse(text);
+            } catch {
+              text = text;
+            }
+            resolve(text);
           } else {
             reject(xhr.statusText);
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enhanced-gog",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "enhances gog web experience",
   "main": "src/index.js",
   "author": "kevinfiol",

--- a/src/util.js
+++ b/src/util.js
@@ -73,7 +73,15 @@ export const request = (method, url, params) => {
 
       xhr.onload = () => {
         if (xhr.status >= 200 && xhr.status < 300) {
-          resolve(xhr.response);
+          let text = xhr.response;
+
+          try {
+            text = JSON.parse(text);
+          } catch {
+            text = text;
+          }
+
+          resolve(text);
         } else {
           reject(xhr.statusText);
         }


### PR DESCRIPTION
Hello,

First off, thanks loads for the userscript and the work you've put into it.
Also, I've not touched JavaScript until today so I very likely will sound like a noob, and I'm not sure how you'd prefer your versioning done, so I hope you don't that I've incremented it with the change.

Qutebrowser has builtin 'greasemonkey support' as they call it. Unfortunately as of now `GM_xmlhttpRequest` is not implemented. All in all this is not a problem as this script very nicely seems to fall back to `XMLHttpRequest`, the issue that follows though is that the attempt to parse the response as JSON doesn't happen when `XMLHttpRequest` is used. This causes the script to error out when checking for `res[".meta"].match` as `res` is not a JSON object and has no properties.

All this diff does is duplicate the the `JSON.parse()` stuff from the `GM_xmlhttpRequest` block.

Thanks,
