### PR TITLE
Set body only for POST requests

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -28,7 +28,7 @@ export const request = (method, url, { params = {}, body = {} }) => {
       xhr({
         method: method,
         url: `${url}?${queryStr}`,
-        data: JSON.stringify(body),
+        data: method === 'POST' ? JSON.stringify(body) : null,
         headers: { 'Content-Type': 'application/json' },
         onload: res => {
           let json = {};


### PR DESCRIPTION
The issue is coming from the reuse of request() function which is adding body to the payload unconditionally. I have tested only the window.GM_xmlhttpRequest branch, but AFAIK XMLHttpRequest can perfectly set body for GET\HEAD requests, as it's not restricted by the spec.

Closes #15