### PR TITLE
Adding support for dark mode

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -1,5 +1,5 @@
 import { m, redraw } from 'umhi';
-import { createPriceFormatter } from './util';
+import { createPriceFormatter, isDarkMode } from './util';
 import { getPriceData } from './itad';
 import { persistUserSettings } from './storage';
 import region_map from './data/region_map.json';
@@ -153,10 +153,11 @@ export const CountrySelect = ({ state, actions }) => {
       m('p',
         m('select', {
           style: {
-            border: '1px solid #cecece',
+            border: isDarkMode() ? '1px solid #404040' : '1px solid #cecece',
             padding: '0.4em',
             margin: '0.5em 0 0 0',
-            backgroundColor: '#f6f6f6'
+            backgroundColor: isDarkMode() ? '#212121' : '#f6f6f6',
+            color: isDarkMode() ? '#f2f2f2' : '#000000'
           },
 
           value: countryValue,

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,12 @@ if (product && typeof product === 'object') {
   document.querySelector('div.product-actions').appendChild(container);
   mount(container, () => App({ state, actions }));
 
+  const themeObserver = new MutationObserver(() => redraw());
+  themeObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme']
+  });
+
   // fetch price data
   getPriceData(state.gameTitle, state.userCountry)
     .then(([priceData, error]) => {

--- a/src/util.js
+++ b/src/util.js
@@ -20,6 +20,9 @@ export const getDateStr = timestamp => {
   return `${month}/${day}/${year}`;
 };
 
+export const isDarkMode = () => 
+  document.documentElement.getAttribute('data-theme') === 'dark';
+
 export const request = (method, url, { params = {}, body = {} }) => {
   const queryArr = Object.keys(params).map(key => {
     return `${ encodeURIComponent(key) }=${ encodeURIComponent(params[key]) }`;


### PR DESCRIPTION
When using the dark mode on GOG, the "Enhanced GOG region" dropdown just shows up with white text and a white background-color. This fixes that.
Also takes the light mode into consideration, and will automatically update the colors when switching from one to the other and back again.